### PR TITLE
feat: add a default PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+**[Ticket](https://linear.app/gnosis-pay/issue/ENG-XX/)**
+
+## 📝 Description
+
+<!-- Describe what you did, unless obvious from the title. Include context about why this change was needed. -->
+
+## 🎯 Changes Made
+
+<!-- List the main changes you made -->
+
+- [ ] ...
+- [ ] ...
+- [ ] ...
+
+## 📸 Visual Changes
+
+<!-- If this PR includes UI changes, please add screenshots or demo videos here -->
+
+## 📝 Additional Notes
+
+<!-- Any additional information that reviewers should know -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**[Ticket](https://linear.app/gnosis-pay/issue/ENG-XX/)**
+**Closes [#TICKET-NUMBER](https://github.com/gnosispay/ui/issues/TICKET-NUMBER)**
 
 ## 📝 Description
 


### PR DESCRIPTION
**Closes [ENG-2620](https://linear.app/gnosis-pay/issue/ENG-2620/add-pr-github-template-for-gnosis-pay-ui-repo)**

## 📝 Description

This PR introduces a default PR template.

## 🎯 Changes Made

- [ ] Introduced a default GitHub PR template

## 📸 Visual Changes

❌ 

## 📝 Additional Notes

After merging this PR to the `main` branch, this pull request template will be used by default for future PRs.