### PR TITLE
fix(ui): fix logic for showing transactions fetching error

### DIFF
--- a/src/components/transactions/transactions.tsx
+++ b/src/components/transactions/transactions.tsx
@@ -30,7 +30,7 @@ export const Transactions = () => {
   const grouped = groupByDate(sorted);
   const dateOrder = Object.keys(grouped).sort((a, b) => new Date(b).getTime() - new Date(a).getTime());
 
-  if (!isTransactionFetchError) {
+  if (isTransactionFetchError) {
     return <TransactionFetchingAlert />;
   }
 


### PR DESCRIPTION
**Closes [ENG-2636](https://linear.app/gnosis-pay/issue/ENG-2636/ui-components-always-show-error-fetching-transactions)**

## 📝 Description

This PR fixes the logic for showing the transactions fetching error.

## 🎯 Changes Made

<!-- List the main changes you made -->

- [ ] Fixed condition for showing transactions fetching error

## 📸 Visual Changes

❌ 

## 📝 Additional Notes

❌ 