### PR TITLE
Cleaner implementation of the Tos signing

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import type { GetApiV1UserTermsResponse } from "./client";
+
 export interface CurrencyInfo {
   tokenSymbol?: string;
   address?: string;
@@ -30,28 +32,14 @@ export const currencies: Record<string, CurrencyInfo> = {
   },
 };
 
-enum UserTermsType {
-  GeneralTos = "general-tos",
-  CardMonovateTos = "card-monavate-tos",
-  CashbackTos = "cashback-tos",
-}
+// Helper type to extract the 'type' property from the array element of GetApiV1UserTermsResponse["terms"]
+export type UserTermsTypeFromApi = NonNullable<NonNullable<GetApiV1UserTermsResponse["terms"]>[number]["type"]>;
 
-export const userTerms: Record<UserTermsType, { title: string; version: string; url: string }> = {
-  [UserTermsType.GeneralTos]: {
-    title: "Gnosis Pay Terms of Service",
-    version: "TOS_GENERAL_VERSION_1",
-    url: "https://legal.gnosispay.com/en/articles/8911632-gnosis-pay-terms-of-service",
-  },
-  [UserTermsType.CardMonovateTos]: {
-    title: "Cardholder Terms of Service",
-    version: "TOS_CARD_VERSION_1",
-    url: "https://legal.gnosispay.com/en/articles/8911633-monavate-cardholder-terms-eea",
-  },
-  [UserTermsType.CashbackTos]: {
-    title: "Cashback Terms of Service",
-    version: "TOS_CASHBACK_2024-08-01",
-    url: "https://forum.gnosis.io/t/gip-110-should-the-gnosis-dao-create-and-fund-a-gnosis-pay-rewards-program-with-10k-gno/8837",
-  },
+// this is strongly typed to the API response
+export const userTermsTitle: Record<UserTermsTypeFromApi, string> = {
+  "general-tos": "Gnosis Pay Terms of Service",
+  "card-monavate-tos": "Cardholder Terms of Service",
+  "cashback-tos": "Cardholder Cashback Terms of Service",
 };
 
 export const GNOSIS_PAY_SETTLEMENT_ADDRESS = "0x4822521E6135CD2599199c83Ea35179229A172EE";

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -73,7 +73,7 @@ export const SignUpRoute = () => {
       if (!tosForUser) return;
 
       // accept all terms that are not already accepted
-      // and that we display in the UI with their respective link
+      // since we displayed all of them in the UI with their respective link
       for (const term of tosForUser) {
         if (!term.type || !term.currentVersion) continue;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
 
     /* Linting */
     "strict": true,
+    "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true


### PR DESCRIPTION
**Closes [ENG-2713](https://linear.app/gnosis-pay/issue/ENG-2713/cleaner-implementation-of-the-tos-sigup)**

## 📝 Description

Following what I've put in the docs here: https://github.com/gnosispay/apps-monorepo/pull/1487 where we should get the urls, types etc from the api, rather than hardcoding them. 
## 🎯 Changes Made

- get the tos
- call the signing off depending on the initial query
- no more hard coding of urls etc
- 
## 📸 Visual Changes

none

