### PR TITLE
Handle voided

### DIFF
--- a/src/components/cards-carousel/card-actions.tsx
+++ b/src/components/cards-carousel/card-actions.tsx
@@ -19,9 +19,15 @@ export const CardActions = ({ card }: { card: Card }) => {
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const [isChangePinModalOpen, setIsChangePinModalOpen] = useState(false);
   const cardInfo = cardInfoMap?.[card.id];
-  const canReport = card.activatedAt && !cardInfo?.isFrozen && !cardInfo?.isStolen && !cardInfo?.isLost;
+  const canReport =
+    card.activatedAt && !cardInfo?.isFrozen && !cardInfo?.isStolen && !cardInfo?.isLost && cardInfo?.isVoid;
   const canChangePin =
-    !card.virtual && card.activatedAt && !cardInfo?.isFrozen && !cardInfo?.isStolen && !cardInfo?.isLost;
+    !card.virtual &&
+    card.activatedAt &&
+    !cardInfo?.isFrozen &&
+    !cardInfo?.isStolen &&
+    !cardInfo?.isLost &&
+    cardInfo?.isVoid;
 
   const onShowCardDetails = (cardToken?: string) => {
     if (!cardToken) {

--- a/src/components/cards-carousel/card-preview.tsx
+++ b/src/components/cards-carousel/card-preview.tsx
@@ -15,6 +15,7 @@ export const CardPreview = ({ cardType, last4, cardInfo }: CardPreviewProps) => 
       {cardInfo.isFrozen && <CardStatusOverlay status="frozen" />}
       {cardInfo.isStolen && <CardStatusOverlay status="stolen" />}
       {cardInfo.isLost && <CardStatusOverlay status="lost" />}
+      {cardInfo.isVoid && <CardStatusOverlay status="void" />}
       <div className="absolute left-4 bottom-4 flex flex-col items-start">
         <span className="text-secondary text-sm font-medium mb-1">{cardType}</span>
         <div className="flex items-center text-white text-lg font-semibold">

--- a/src/components/cards-carousel/card-status-overlay.tsx
+++ b/src/components/cards-carousel/card-status-overlay.tsx
@@ -1,11 +1,11 @@
-import { AlertTriangle, Snowflake } from "lucide-react";
+import { AlertTriangle, Snowflake, Ban } from "lucide-react";
 
 interface CardStatusOverlayProps {
-  status: "frozen" | "stolen" | "lost";
+  status: "frozen" | "stolen" | "lost" | "void";
 }
 
 export const CardStatusOverlay = ({ status }: CardStatusOverlayProps) => {
-  const statusConfig = {
+  const statusConfig: Record<CardStatusOverlayProps["status"], { icon: React.ReactNode; text: string }> = {
     frozen: {
       icon: <Snowflake size={40} className="text-white mb-2" />,
       text: "FROZEN",
@@ -17,6 +17,10 @@ export const CardStatusOverlay = ({ status }: CardStatusOverlayProps) => {
     lost: {
       icon: <AlertTriangle size={40} className="text-white mb-2" />,
       text: "LOST",
+    },
+    void: {
+      icon: <Ban size={40} className="text-white mb-2" />,
+      text: "VOID",
     },
   };
 


### PR DESCRIPTION
**Closes [ENG-3016](https://linear.app/gnosis-pay/issue/ENG-3016/add-status-visual-representation-for-voided-cards)**

## 📝 Description

Show voided cards

## 📸 Visual Changes

<img width="1762" height="933" alt="image" src="https://github.com/user-attachments/assets/2c52023a-3d6b-46d9-8c2f-50862160f750" />
