### PR TITLE
Fix cors for gp-ui.pages.dev

### DIFF
--- a/pse-backend-demo/src/server.ts
+++ b/pse-backend-demo/src/server.ts
@@ -14,9 +14,9 @@ const CORS_CONFIG = {
   staticOrigins: ["https://verified-pug-renewing.ngrok-free.app", "http://localhost"],
   // Pattern for dynamic subdomain matching
   patterns: [
-    /^https:\/\/[a-zA-Z0-9-]+\.gp-ui\.pages\.dev$/,
+    /^https:\/\/([a-zA-Z0-9-]+\.)*gp-ui\.pages\.dev$/,
     /^http:\/\/localhost:[0-9-]+$/,
-    /^https:\/\/([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.gnosispay\.com$/,
+    /^https:\/\/([a-zA-Z0-9-]+\.)*gnosispay\.com$/,
   ],
 };
 


### PR DESCRIPTION
allow any subdomain, but also the main domain `gp-ui.pages.dev` without subdomain.