### PR TITLE
Show banner and balance info for unspendable funds

### DIFF
--- a/src/components/balances.tsx
+++ b/src/components/balances.tsx
@@ -1,12 +1,14 @@
 import { useUser } from "@/context/UserContext";
 import { useMemo } from "react";
-import { Clock } from "lucide-react";
+import { CircleMinus, Clock } from "lucide-react";
 import { Skeleton } from "./ui/skeleton";
 import { currencies } from "../constants";
 import { formatCurrency } from "@/utils/formatCurrency";
+import { useUnspendableAmount } from "@/hooks/useUnspendableAmount";
 
 export const Balances = () => {
   const { balances, safeConfig } = useUser();
+  const { unspendableFormatted, shouldShowAlert } = useUnspendableAmount();
   const currencyInfo = useMemo(() => {
     if (!safeConfig?.fiatSymbol) {
       return;
@@ -40,8 +42,14 @@ export const Balances = () => {
       )}
       {balances?.pending && balances.pending !== "0" && (
         <div className="text-secondary flex items-center gap-1">
-          <Clock className="w-6 h-6" aria-hidden="true" />
+          <Clock className="w-4 h-4" aria-hidden="true" />
           {formattedPending} pending
+        </div>
+      )}
+      {shouldShowAlert && (
+        <div className="text-secondary flex items-center gap-1">
+          <CircleMinus className="w-4 h-4" aria-hidden="true" />
+          {unspendableFormatted} not spendable
         </div>
       )}
     </div>

--- a/src/components/unspendable-amount-alert.tsx
+++ b/src/components/unspendable-amount-alert.tsx
@@ -1,0 +1,37 @@
+import { HELP_CENTER_URL } from "@/constants";
+import { StandardAlert } from "./ui/standard-alert";
+import { useUnspendableAmount } from "@/hooks/useUnspendableAmount";
+import { useZendesk } from "react-use-zendesk";
+
+export const UnspendableAmountAlert = () => {
+  const { unspendableFormatted, shouldShowAlert } = useUnspendableAmount();
+  const { open } = useZendesk();
+
+  if (!shouldShowAlert) {
+    return null;
+  }
+  return (
+    <StandardAlert
+      className="mb-4"
+      variant="destructive"
+      description={
+        <span>
+          A deposit into your account did not pass validation check and {unspendableFormatted} are unspendable. Please{" "}
+          <button type="button" className="text-muted-foreground underline cursor-pointer" onClick={open}>
+            contact support
+          </button>{" "}
+          or{" "}
+          <a
+            href={HELP_CENTER_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground underline cursor-pointer"
+          >
+            visit our help center
+          </a>{" "}
+          for more info.
+        </span>
+      }
+    />
+  );
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1631,3 +1631,5 @@ export const COUPON_CODES = "GPUI100";
 
 export const ZENDESK_USER_ID_FIELD_ID = "40875525876372";
 export const ZENDESK_PARTNER_TAG_VALUE = "GnosisPay v2app";
+
+export const HELP_CENTER_URL = "https://help.gnosispay.com/";

--- a/src/hooks/useUnspendableAmount.ts
+++ b/src/hooks/useUnspendableAmount.ts
@@ -1,0 +1,31 @@
+import { useMemo } from "react";
+import { useUser } from "@/context/UserContext";
+import { currencies } from "@/constants";
+import { formatCurrency } from "@/utils/formatCurrency";
+
+export const useUnspendableAmount = () => {
+  const { balances, safeConfig } = useUser();
+
+  const currencyInfo = useMemo(() => {
+    if (!safeConfig?.fiatSymbol) {
+      return;
+    }
+
+    return currencies[safeConfig.fiatSymbol];
+  }, [safeConfig?.fiatSymbol]);
+
+  const unspendableData = useMemo(() => {
+    const spendableBn = BigInt(balances?.spendable ?? "0");
+    const totalBn = BigInt(balances?.total ?? "0");
+    const unspendableBn = totalBn - spendableBn;
+
+    return {
+      unspendableFormatted: formatCurrency(unspendableBn.toString(), currencyInfo),
+      unspendableBn,
+      hasUnspendableAmount: unspendableBn > 0n,
+      shouldShowAlert: balances?.pending === "0" && unspendableBn > 0n,
+    };
+  }, [balances?.total, balances?.spendable, balances?.pending, currencyInfo]);
+
+  return unspendableData;
+};

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/account";
 import { DailyLimitModal } from "@/components/modals/daily-limit";
 import { SafeOwnersModal } from "@/components/modals/safe-owners";
+import { HELP_CENTER_URL } from "@/constants";
 
 enum ModalType {
   NONE = "none",
@@ -70,7 +71,7 @@ export const AccountRoute = () => {
           <AccountSection
             icon={<LifeBuoyIcon className="w-6 h-6" />}
             title="Help Center"
-            onClick={() => window.open("https://help.gnosispay.com/", "_blank")}
+            onClick={() => window.open(HELP_CENTER_URL, "_blank")}
           />
         </div>
       </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { StatusHelpIcon } from "@/components/ui/status-help-icon";
 import { PartnerBanner } from "@/components/ui/partner-banner";
+import { UnspendableAmountAlert } from "@/components/unspendable-amount-alert";
 
 export const Home = () => {
   const [sendFundsModalOpen, setSendFundsModalOpen] = useState(false);
@@ -21,6 +22,7 @@ export const Home = () => {
       <div className="col-span-6 lg:col-start-2 lg:col-span-4">
         <div className="mx-4 lg:mx-0">
           <PendingCardOrder />
+          <UnspendableAmountAlert />
         </div>
         <div className="grid grid-cols-3 gap-4">
           <div className="col-span-3 mx-4 lg:mx-0 lg:col-span-2">


### PR DESCRIPTION
**Closes https://linear.app/gnosis-pay/issue/ENG-3182/show-a-banner-when-spendable-total-and-pending-===-0**

## 📝 Description

Show a banner + balance according to the design. I don't have an unspendable amount, so I had to force the banner, and it shows 0€ as a result.

Clicking on the "contact support" link opens the support chat.

## 📸 Visual Changes

<img width="1708" height="487" alt="image" src="https://github.com/user-attachments/assets/1331a84e-1ec0-4e5f-a6cf-812520258f6e" />
