### PR TITLE
Adjust headingtext sizes and bg color

### DIFF
--- a/src/components/account/UserProfileHeader.tsx
+++ b/src/components/account/UserProfileHeader.tsx
@@ -17,7 +17,7 @@ export const UserProfileHeader = () => {
 
   return (
     <div className="flex flex-col items-center space-y-4">
-      <div className="w-20 h-20 rounded-full bg-muted flex items-center justify-center text-2xl font-semibold text-muted-foreground">
+      <div className="w-20 h-20 rounded-full bg-icon-background flex items-center justify-center text-2xl font-semibold text-primary">
         {userInitials}
       </div>
       <h1 className="text-2xl font-semibold text-foreground text-center">{userDisplayName}</h1>

--- a/src/components/balances.tsx
+++ b/src/components/balances.tsx
@@ -29,7 +29,7 @@ export const Balances = () => {
 
   return (
     <div className="flex flex-col gap-2 mb-4 mx-4 lg:mx-0">
-      <h1 className="font-bold text-secondary">Balance</h1>
+      <h1 className="font-bold text-secondary text-lg">Balance</h1>
       {formattedBalance ? (
         <div className="text-4xl text-primary font-bold">
           {formattedBalance.split(".")[0]}

--- a/src/components/modals/transaction-details/bank-transfer-details-modal.tsx
+++ b/src/components/modals/transaction-details/bank-transfer-details-modal.tsx
@@ -96,12 +96,12 @@ export const BankTransferDetailsModal = ({ ibanOrder, isOpen, onClose }: BankTra
                   <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
                 </div>
                 <div className="flex-1">
-                  <div className="text-xl text-foreground font-normal">{transferTitle}</div>
+                  <div className="text-lg text-foreground font-normal">{transferTitle}</div>
                   <div className="text-xs text-muted-foreground">{formattedDate}</div>
                 </div>
               </div>
               <div className="text-center sm:text-right">
-                <div className="text-xl text-foreground font-normal">
+                <div className="text-lg text-foreground font-normal">
                   {formattedAmount ? `${sign} ${formattedAmount}` : "-"}
                 </div>
               </div>

--- a/src/components/modals/transaction-details/bank-transfer-details-modal.tsx
+++ b/src/components/modals/transaction-details/bank-transfer-details-modal.tsx
@@ -92,8 +92,8 @@ export const BankTransferDetailsModal = ({ ibanOrder, isOpen, onClose }: BankTra
           <DialogTitle className="pb-4 mt-4">
             <div className="flex flex-col sm:flex-row sm:items-center gap-3">
               <div className="flex items-center gap-3 flex-1">
-                <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center">
-                  <Icon className="w-6 h-6 text-muted-foreground" aria-hidden="true" />
+                <div className="w-12 h-12 rounded-full bg-icon-background flex items-center justify-center">
+                  <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
                 </div>
                 <div className="flex-1">
                   <div className="text-xl text-foreground font-normal">{transferTitle}</div>

--- a/src/components/modals/transaction-details/onchain-transfer-details-modal.tsx
+++ b/src/components/modals/transaction-details/onchain-transfer-details-modal.tsx
@@ -62,8 +62,8 @@ export const OnchainTransferDetailsModal = ({
           <DialogTitle className="pb-4 mt-4">
             <div className="flex flex-col sm:flex-row sm:items-center gap-3">
               <div className="flex items-center gap-3 flex-1">
-                <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center">
-                  <Icon className="w-6 h-6 text-muted-foreground" aria-hidden="true" />
+                <div className="w-12 h-12 rounded-full bg-icon-background flex items-center justify-center">
+                  <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
                 </div>
                 <div className="flex-1">
                   <div className="text-xl text-foreground font-normal">{transferTitle}</div>

--- a/src/components/modals/transaction-details/onchain-transfer-details-modal.tsx
+++ b/src/components/modals/transaction-details/onchain-transfer-details-modal.tsx
@@ -66,12 +66,12 @@ export const OnchainTransferDetailsModal = ({
                   <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
                 </div>
                 <div className="flex-1">
-                  <div className="text-xl text-foreground font-normal">{transferTitle}</div>
+                  <div className="text-lg text-foreground font-normal">{transferTitle}</div>
                   <div className="text-xs text-muted-foreground">{formattedDate}</div>
                 </div>
               </div>
               <div className="text-center sm:text-right">
-                <div className="text-xl text-foreground font-normal">
+                <div className="text-lg text-foreground font-normal">
                   {formattedValue ? `${sign} ${formattedValue}` : "-"}
                 </div>
               </div>

--- a/src/components/modals/transaction-details/transaction-details-modal.tsx
+++ b/src/components/modals/transaction-details/transaction-details-modal.tsx
@@ -128,14 +128,14 @@ export const TransactionDetailsModal = ({ transaction, isOpen, onClose }: Transa
                   <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
                 </div>
                 <div className="flex-1">
-                  <div className="text-xl text-foreground font-normal">{merchantName}</div>
+                  <div className="text-lg text-foreground font-normal">{merchantName}</div>
                   <div className="text-xs text-muted-foreground">
                     {format(parseISO(transaction.createdAt || ""), "MMM dd, yyyy 'at' HH:mm")}
                   </div>
                 </div>
               </div>
               <div className="text-center sm:text-right">
-                <div className={`text-xl text-foreground font-normal`}>
+                <div className={`text-lg text-foreground font-normal`}>
                   {billAmount ? `${sign} ${billAmount}` : "-"}
                 </div>
                 {txAmount !== billAmount && txAmount && (

--- a/src/components/modals/transaction-details/transaction-details-modal.tsx
+++ b/src/components/modals/transaction-details/transaction-details-modal.tsx
@@ -124,8 +124,8 @@ export const TransactionDetailsModal = ({ transaction, isOpen, onClose }: Transa
           <DialogTitle className="pb-4 mt-4">
             <div className="flex flex-col sm:flex-row sm:items-center gap-3">
               <div className="flex items-center gap-3 flex-1">
-                <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center">
-                  <Icon className="w-6 h-6 text-muted-foreground" aria-hidden="true" />
+                <div className="w-12 h-12 rounded-full bg-icon-background flex items-center justify-center">
+                  <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
                 </div>
                 <div className="flex-1">
                   <div className="text-xl text-foreground font-normal">{merchantName}</div>

--- a/src/components/transactions/bank-transfer-row.tsx
+++ b/src/components/transactions/bank-transfer-row.tsx
@@ -56,7 +56,7 @@ export const BankTransferRow = ({ ibanOrder }: BankTransferRowProps) => {
             <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
           </div>
           <div className="flex flex-col">
-            <div>{transferTitle}</div>
+            <div className="text-lg">{transferTitle}</div>
             <div className="text-xs text-secondary mt-1">
               {transferTime}
               {memo && <span className="mx-1"> • {memo}</span>}
@@ -64,7 +64,7 @@ export const BankTransferRow = ({ ibanOrder }: BankTransferRowProps) => {
           </div>
         </div>
         <div className="text-right">
-          <div className="text-xl text-primary">{formattedAmount}</div>
+          <div className="text-lg text-primary">{formattedAmount}</div>
         </div>
       </button>
 

--- a/src/components/transactions/bank-transfer-row.tsx
+++ b/src/components/transactions/bank-transfer-row.tsx
@@ -52,8 +52,8 @@ export const BankTransferRow = ({ ibanOrder }: BankTransferRowProps) => {
         type="button"
       >
         <div className="flex items-center gap-3">
-          <div className="w-12 h-12 rounded-full bg-icon-card-bg flex items-center justify-center">
-            <Icon className="w-6 h-6 text-icon-card" aria-hidden="true" />
+          <div className="w-12 h-12 rounded-full bg-icon-background flex items-center justify-center">
+            <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
           </div>
           <div className="flex flex-col">
             <div>{transferTitle}</div>

--- a/src/components/transactions/onchain-transfer-row.tsx
+++ b/src/components/transactions/onchain-transfer-row.tsx
@@ -41,14 +41,14 @@ export const OnchainTransferRow = ({ transfer, currency }: OnchainTransferRowPro
             <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
           </div>
           <div className="flex flex-col">
-            <div className="text-xl text-primary">
+            <div className="text-lg text-primary">
               {isIncoming ? "From" : "To"} {shortenAddress(isIncoming ? transfer.from : transfer.to)}
             </div>
             <div className="text-xs text-secondary mt-1">{format(transfer.date, "HH:mm")}</div>
           </div>
         </div>
         <div className="text-right">
-          <div className="text-xl text-primary">{formattedValue ? `${sign} ${formattedValue}` : "-"}</div>
+          <div className="text-lg text-primary">{formattedValue ? `${sign} ${formattedValue}` : "-"}</div>
         </div>
       </button>
 

--- a/src/components/transactions/onchain-transfer-row.tsx
+++ b/src/components/transactions/onchain-transfer-row.tsx
@@ -37,8 +37,8 @@ export const OnchainTransferRow = ({ transfer, currency }: OnchainTransferRowPro
         type="button"
       >
         <div className="flex items-center gap-3">
-          <div className="w-12 h-12 rounded-full bg-icon-card-bg flex items-center justify-center">
-            <Icon className="w-6 h-6 text-icon-card" aria-hidden="true" />
+          <div className="w-12 h-12 rounded-full bg-icon-background flex items-center justify-center">
+            <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
           </div>
           <div className="flex flex-col">
             <div className="text-xl text-primary">

--- a/src/components/transactions/transaction-row.tsx
+++ b/src/components/transactions/transaction-row.tsx
@@ -62,7 +62,7 @@ export const TransactionRow = ({ transaction }: TransactionRowProps) => {
             <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
           </div>
           <div>
-            <div className="text-xl text-foreground">{merchantName}</div>
+            <div className="text-lg text-foreground">{merchantName}</div>
             <div className="text-xs text-muted-foreground">
               {time}
               {isRefund && (
@@ -88,7 +88,7 @@ export const TransactionRow = ({ transaction }: TransactionRowProps) => {
           </div>
         </div>
         <div className="text-right">
-          <div className={`text-xl text-foreground ${isStrikethrough ? "line-through" : ""}`}>
+          <div className={`text-lg text-foreground ${isStrikethrough ? "line-through" : ""}`}>
             {billAmount ? `${sign} ${billAmount}` : "-"}
           </div>
           {txAmount !== billAmount && <div className="text-xs text-muted-foreground mt-1">{`${sign} ${txAmount}`}</div>}

--- a/src/components/transactions/transaction-row.tsx
+++ b/src/components/transactions/transaction-row.tsx
@@ -58,8 +58,8 @@ export const TransactionRow = ({ transaction }: TransactionRowProps) => {
         type="button"
       >
         <div className="flex items-center gap-3">
-          <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center">
-            <Icon className="w-6 h-6 text-muted-foreground" aria-hidden="true" />
+          <div className="w-12 h-12 rounded-full bg-icon-background flex items-center justify-center">
+            <Icon className="w-6 h-6 text-primary" aria-hidden="true" />
           </div>
           <div>
             <div className="text-xl text-foreground">{merchantName}</div>

--- a/src/index.css
+++ b/src/index.css
@@ -101,6 +101,7 @@
   --switch-unchecked-thumb: var(--neutral-50);
   --switch-checked-bg: var(--brand-500);
   --switch-checked-thumb: var(--neutral-50);
+  --color-icon-background: var(--neutral-300);
 }
 
 @media (prefers-color-scheme: light) {
@@ -166,6 +167,7 @@
   --color-switch-unchecked-thumb: var(--switch-unchecked-thumb);
   --color-switch-checked-bg: var(--switch-checked-bg);
   --color-switch-checked-thumb: var(--switch-checked-thumb);
+  --color-icon-background: var(--color-icon-background);
 }
 
 .dark {
@@ -223,6 +225,7 @@
   --switch-unchecked-thumb: var(--neutral-50);
   --switch-checked-bg: var(--brand-500);
   --switch-checked-thumb: var(--neutral-900);
+  --color-icon-background: var(--neutral-500);
 }
 
 @layer base {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -39,19 +39,19 @@ export const Home = () => {
         <div className="grid grid-cols-3 gap-4">
           <div className="col-span-3 mx-4 lg:mx-0 lg:col-span-2">
             <div className="flex items-center justify-between mb-4">
-              <h1 className="font-bold text-secondary">Transactions</h1>
+              <h1 className="font-bold text-secondary text-lg">Transactions</h1>
             </div>
             <Transactions />
           </div>
           <div className="col-span-3 mx-4 lg:mx-0 lg:col-span-1 lg:col-start-3">
             <div className="flex items-center justify-between mb-4">
-              <h1 className="font-bold text-secondary">
+              <h1 className="font-bold text-secondary text-lg">
                 Rewards <StatusHelpIcon type="rewards" />
               </h1>
             </div>
             <Rewards />
             <div className="flex items-center justify-between mb-4 mt-6">
-              <h1 className="font-bold text-secondary">Cards</h1>
+              <h1 className="font-bold text-secondary text-lg">Cards</h1>
               <Link to="/cards" className="flex items-center gap-2">
                 View details <ChevronRight size={16} />
               </Link>


### PR DESCRIPTION
**Closes https://linear.app/gnosis-pay/issue/ENG-3159/adjust-headingtext-sizes and https://linear.app/gnosis-pay/issue/ENG-3160/avatar-bg**

## 📝 Description

A bunch of small adjustments according the design review


## 📸 Visual Changes

<img width="1143" height="614" alt="image" src="https://github.com/user-attachments/assets/1ff73419-ab69-444b-90ad-ae43d954e34f" />
<img width="1307" height="943" alt="image" src="https://github.com/user-attachments/assets/04fccb08-64b7-4045-b08f-f8b1c09a2c61" />
