### PR TITLE
Fix signing URL domain + corder rounded

### DIFF
--- a/src/components/card-order/AddressCheckSkeleton.tsx
+++ b/src/components/card-order/AddressCheckSkeleton.tsx
@@ -12,7 +12,7 @@ export const AddressCheckSkeleton = () => {
         {/* Left Column - Order Details Skeleton */}
         <div className="space-y-6">
           {/* Order Details Card Skeleton */}
-          <div className="bg-card rounded-xl p-6">
+          <div className="bg-card rounded-lg p-6">
             <Skeleton className="h-6 w-32 mb-4" />
             <div className="space-y-3">
               <div>
@@ -23,7 +23,7 @@ export const AddressCheckSkeleton = () => {
           </div>
 
           {/* Shipping Address Card Skeleton */}
-          <div className="bg-card rounded-xl p-6">
+          <div className="bg-card rounded-lg p-6">
             <Skeleton className="h-6 w-36 mb-4" />
             <div className="space-y-2">
               <Skeleton className="h-4 w-full" />
@@ -37,7 +37,7 @@ export const AddressCheckSkeleton = () => {
         {/* Right Column - Summary Skeleton */}
         <div className="space-y-6">
           {/* Summary Card Skeleton */}
-          <div className="bg-card rounded-xl p-6">
+          <div className="bg-card rounded-lg p-6">
             <Skeleton className="h-6 w-20 mb-4" />
             <div className="space-y-3">
               <div className="flex justify-between">
@@ -51,7 +51,7 @@ export const AddressCheckSkeleton = () => {
           </div>
 
           {/* Total Card Skeleton */}
-          <div className="bg-card rounded-xl p-6">
+          <div className="bg-card rounded-lg p-6">
             <div className="flex justify-between">
               <Skeleton className="h-6 w-12" />
               <div className="text-right space-y-1">

--- a/src/components/card-order/AddressCheckStep.tsx
+++ b/src/components/card-order/AddressCheckStep.tsx
@@ -166,7 +166,7 @@ export const AddressCheckStep = ({ orderId, onNext }: AddressCheckStepProps) => 
         {/* Left Column - Order Details */}
         <div className="space-y-6">
           {/* Order Details */}
-          <div className="bg-card rounded-xl p-6">
+          <div className="bg-card rounded-lg p-6">
             <h3 className="text-lg font-medium text-foreground mb-4">Order details</h3>
             <div className="space-y-3">
               {order.embossedName && (
@@ -179,7 +179,7 @@ export const AddressCheckStep = ({ orderId, onNext }: AddressCheckStepProps) => 
           </div>
 
           {/* Shipping Address */}
-          <div className="bg-card rounded-xl p-6">
+          <div className="bg-card rounded-lg p-6">
             <h3 className="text-lg font-medium text-foreground mb-4">Shipping address</h3>
             <div className="text-sm">{formatAddress(order)}</div>
           </div>
@@ -188,7 +188,7 @@ export const AddressCheckStep = ({ orderId, onNext }: AddressCheckStepProps) => 
         {/* Right Column - Summary */}
         <div className="space-y-6">
           {/* Summary */}
-          <div className="bg-card rounded-xl p-6">
+          <div className="bg-card rounded-lg p-6">
             <h3 className="text-lg font-medium text-foreground mb-4">Summary</h3>
             <div className="space-y-3">
               <div className="flex justify-between">
@@ -207,7 +207,7 @@ export const AddressCheckStep = ({ orderId, onNext }: AddressCheckStepProps) => 
             )}
           </div>
 
-          <div className="bg-card rounded-xl p-6">
+          <div className="bg-card rounded-lg p-6">
             <div className="flex justify-between text-lg font-semibold">
               <span>TOTAL</span>
               <div className="text-right">

--- a/src/components/cards.tsx
+++ b/src/components/cards.tsx
@@ -29,7 +29,7 @@ export const Cards = () => {
 
   return (
     <>
-      <div className="flex flex-col gap-4 bg-card p-4 rounded-xl">
+      <div className="flex flex-col gap-4 bg-card p-4 rounded-lg">
         {isLoading &&
           [1, 2, 3].map((i) => (
             <div key={`skeleton-${i}`} className="flex items-center gap-4">

--- a/src/components/pending-card-order.tsx
+++ b/src/components/pending-card-order.tsx
@@ -43,7 +43,7 @@ export const PendingCardOrder = () => {
   const pendingOrder = pendingPhysicalOrders[0];
 
   return (
-    <div className="bg-card border border-border rounded-xl p-4 mb-6">
+    <div className="bg-card border border-border rounded-lg p-4 mb-6">
       <div className="flex items-start gap-3">
         <div className="flex-shrink-0 mt-1">
           <Package className="w-5 h-5 text-warning" />

--- a/src/components/rewards.tsx
+++ b/src/components/rewards.tsx
@@ -55,14 +55,14 @@ export const Rewards = () => {
 
   if (error) {
     return (
-      <div className="bg-card p-4 rounded-xl">
+      <div className="bg-card p-4 rounded-lg">
         <StandardAlert variant="destructive" description={error} />
       </div>
     );
   }
 
   return (
-    <div className="bg-card p-4 rounded-xl">
+    <div className="bg-card p-4 rounded-lg">
       {isLoading ? (
         <div className="space-y-4">
           <div className="flex items-center gap-2">

--- a/src/components/transactions/card-transactions.tsx
+++ b/src/components/transactions/card-transactions.tsx
@@ -39,7 +39,7 @@ export const CardTransactions = ({ cardToken }: CardTransactionsProps) => {
   }
 
   return (
-    <div className="flex flex-col gap-4 bg-card p-4 rounded-xl mb-4">
+    <div className="flex flex-col gap-4 bg-card p-4 rounded-lg mb-4">
       {(!transactions || Object.keys(transactions).length === 0) && (
         <div className="flex flex-col items-center justify-center">
           <InboxIcon className="w-10 h-10 mb-2 text-secondary" />

--- a/src/components/transactions/transaction-skeleton.tsx
+++ b/src/components/transactions/transaction-skeleton.tsx
@@ -1,7 +1,7 @@
 import { Skeleton } from "../ui/skeleton";
 
 export const TransactionSkeleton = () => (
-  <div className="flex flex-col gap-4 bg-card p-4 rounded-xl">
+  <div className="flex flex-col gap-4 bg-card p-4 rounded-lg">
     {[1, 2].map((numb) => (
       <div key={`loader-date-${numb}`} className="text-xs text-secondary mb-2">
         <Skeleton className="h-4 w-20 rounded-lg" />

--- a/src/components/transactions/transactions.tsx
+++ b/src/components/transactions/transactions.tsx
@@ -119,7 +119,7 @@ export const Transactions = () => {
   return (
     <div className="flex flex-col gap-4 mb-4">
       {/* Transactions Content */}
-      <div className="bg-card rounded-xl">
+      <div className="bg-card rounded-lg">
         {/* Transaction Tabs */}
         <TransactionTabs value={selectedType} onValueChange={handleTabChange}>
           <TransactionTab value={TransactionType.CARD}>Card</TransactionTab>

--- a/src/components/ui/icon-button.tsx
+++ b/src/components/ui/icon-button.tsx
@@ -17,7 +17,7 @@ const iconButtonVariants = cva(
       size: {
         sm: "w-8 h-8 rounded-lg",
         default: "w-10 h-10 rounded-lg",
-        lg: "w-12 h-12 rounded-xl",
+        lg: "w-12 h-12 rounded-lg",
       },
       layout: {
         standalone: "",

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -134,7 +134,7 @@ const AuthContextProvider = ({ children }: AuthContextProps) => {
       domain: "gnosispay.com",
       address,
       statement: "Sign in with Ethereum to the app.",
-      uri: "https://www.gnosispay.com",
+      uri: "https://my.gnosispay.com",
       version: "1",
       chainId,
       nonce: data,

--- a/src/pages/Cards.tsx
+++ b/src/pages/Cards.tsx
@@ -94,7 +94,7 @@ export const CardsRoute = () => {
       {!cards ||
         (cards.length === 0 && (
           <div className="col-span-6 mx-4 lg:mx-0 lg:col-span-4 lg:col-start-2">
-            <div className="flex flex-col gap-4 bg-card p-4 rounded-xl">
+            <div className="flex flex-col gap-4 bg-card p-4 rounded-lg">
               <div className="flex flex-col items-center justify-center mt-4">
                 <InboxIcon className="w-10 h-10 mb-2 text-secondary" />
                 <div className="text-center text-secondary">No cards found.</div>


### PR DESCRIPTION
**Closes https://linear.app/gnosis-pay/issue/ENG-3158/adjust-rounded-corners**

## 📝 Description

Any `rounded-xl` should have been a `rounded-lg` beside the card.
That's fixed.
Squeezing a small issue in the signing message that resulted in MM showing a warning:
uri: "https://www.gnosispay.com" -> uri: "https://my.gnosispay.com" 

<img width="1376" height="1023" alt="image" src="https://github.com/user-attachments/assets/4494e961-a044-4026-b932-36e5fb266e2c" />
