### PR TITLE
Fix MM warning

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -131,7 +131,7 @@ const AuthContextProvider = ({ children }: AuthContextProps) => {
     }
 
     const message = new SiweMessage({
-      domain: "gnosispay.com",
+      domain: "my.gnosispay.com",
       address,
       statement: "Sign in with Ethereum to the app.",
       uri: "https://my.gnosispay.com",


### PR DESCRIPTION
It looks like Metamask wants to have the subdomain otherwise it shows a warning
<img width="740" height="1093" alt="image" src="https://github.com/user-attachments/assets/b19101e7-0759-49c0-b5c1-a554c2ea391c" />
