### PR TITLE
Add jumper and a link to help center for funding options

### DIFF
--- a/src/components/modals/add-funds/add-funds.tsx
+++ b/src/components/modals/add-funds/add-funds.tsx
@@ -1,10 +1,11 @@
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { useUser } from "@/context/UserContext";
-import { Building2, Download, ArrowLeftRight, ChevronRight } from "lucide-react";
+import { Building2, Download, ArrowLeftRight, ChevronRight, LifeBuoy } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { BankTransferStep } from "./bank-transfer-step";
 import { CryptoStep } from "./crypto-step";
 import { useDebridgeUrl } from "@/hooks/useDebridgeUrl";
+import { useJumperUrl } from "@/hooks/useJumperUrl";
 import { currencies } from "@/constants";
 
 interface AddFundsModalProps {
@@ -34,6 +35,7 @@ export const AddFundsModal = ({ open, onOpenChange }: AddFundsModalProps) => {
   );
 
   const debridgeUrl = useDebridgeUrl();
+  const jumperUrl = useJumperUrl();
 
   const fundingOptions = useMemo(() => {
     const baseOptions = [
@@ -43,6 +45,15 @@ export const AddFundsModal = ({ open, onOpenChange }: AddFundsModalProps) => {
         description: "Send crypto to your Gnosis Card account • ~5 mins",
         onClick: () => {
           setStep(Step.Crypto);
+        },
+      },
+      {
+        icon: ArrowLeftRight,
+        title: "Swap tokens via Jumper",
+        description: `Exchange your crypto for ${currency?.tokenSymbol} • ~5 mins`,
+        onClick: () => {
+          if (!jumperUrl) return;
+          window.open(jumperUrl, "_blank");
         },
       },
       {
@@ -69,36 +80,54 @@ export const AddFundsModal = ({ open, onOpenChange }: AddFundsModalProps) => {
     }
 
     return baseOptions;
-  }, [user?.bankingDetails?.moneriumIban, debridgeUrl, currency?.tokenSymbol]);
+  }, [user?.bankingDetails?.moneriumIban, debridgeUrl, jumperUrl, currency?.tokenSymbol]);
 
   return (
     <Dialog open={open} onOpenChange={onLocalOpenChange}>
       <DialogContent aria-describedby={undefined}>
         <DialogTitle>{step}</DialogTitle>
         <div className="pb-6 space-y-3">
-          {step === Step.Select &&
-            fundingOptions.map((option) => {
-              const IconComponent = option.icon;
-              return (
-                <button
-                  key={option.title}
-                  type="button"
-                  className="cursor-pointer w-full flex items-center gap-4 p-4 rounded-lg border hover:bg-muted/50 transition-colors text-left"
-                  onClick={option.onClick}
-                >
-                  <div className="flex-shrink-0">
-                    <IconComponent className="h-6 w-6 text-foreground" />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <h3 className="font-medium text-foreground mb-1">{option.title}</h3>
-                    <p className="text-sm text-muted-foreground">{option.description}</p>
-                  </div>
-                  <div className="flex-shrink-0">
-                    <ChevronRight className="h-5 w-5 text-muted-foreground" />
-                  </div>
-                </button>
-              );
-            })}
+          {step === Step.Select && (
+            <>
+              {fundingOptions.map((option) => {
+                const IconComponent = option.icon;
+                return (
+                  <button
+                    key={option.title}
+                    type="button"
+                    className="cursor-pointer w-full flex items-center gap-4 p-4 rounded-lg border hover:bg-muted/50 transition-colors text-left"
+                    onClick={option.onClick}
+                  >
+                    <div className="flex-shrink-0">
+                      <IconComponent className="h-6 w-6 text-foreground" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="font-medium text-foreground mb-1">{option.title}</h3>
+                      <p className="text-sm text-muted-foreground">{option.description}</p>
+                    </div>
+                    <div className="flex-shrink-0">
+                      <ChevronRight className="h-5 w-5 text-muted-foreground" />
+                    </div>
+                  </button>
+                );
+              })}
+              <div className="flex items-center gap-2 pt-2 text-sm text-muted-foreground">
+                <LifeBuoy className="h-4 w-4" />
+                <span>
+                  More info about bridging and swaping on our{" "}
+                  <a
+                    href="https://help.gnosispay.com/hc/en-us/articles/39563426086932-Funding-with-Cryptocurrency-Swapping-Bridging"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground underline"
+                  >
+                    help center
+                  </a>
+                  .
+                </span>
+              </div>
+            </>
+          )}
           {step === Step.IBAN && <BankTransferStep onBack={() => setStep(Step.Select)} />}
           {step === Step.Crypto && <CryptoStep onBack={() => setStep(Step.Select)} />}
         </div>

--- a/src/components/modals/add-funds/crypto-step.tsx
+++ b/src/components/modals/add-funds/crypto-step.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { ADD_FUNDS_CONSTANTS, currencies } from "@/constants";
 import { useUser } from "@/context/UserContext";
 import { useDebridgeUrl } from "@/hooks/useDebridgeUrl";
+import { useJumperUrl } from "@/hooks/useJumperUrl";
 import { ExternalLink, ArrowLeft } from "lucide-react";
 import { useMemo } from "react";
 import { SafeAccountDetails } from "@/components/account/SafeAccountDetails";
@@ -18,10 +19,16 @@ export const CryptoStep = ({ onBack }: CryptoStepProps) => {
   }, [safeConfig]);
 
   const debridgeUrl = useDebridgeUrl();
+  const jumperUrl = useJumperUrl();
 
   const handleDeBridgeClick = () => {
     if (!debridgeUrl) return;
     window.open(debridgeUrl, "_blank");
+  };
+
+  const handleJumperClick = () => {
+    if (!jumperUrl) return;
+    window.open(jumperUrl, "_blank");
   };
 
   return (
@@ -46,7 +53,7 @@ export const CryptoStep = ({ onBack }: CryptoStepProps) => {
 
             <div>
               <p className="text-sm text-muted-foreground mb-4">
-                Get {currency?.tokenSymbol} on Gnosis Chain through deBridge below
+                Get {currency?.tokenSymbol} on Gnosis Chain through bridge services below
               </p>
               <a
                 href={ADD_FUNDS_CONSTANTS.GNOSIS_PAY_HELP_URL}
@@ -58,11 +65,16 @@ export const CryptoStep = ({ onBack }: CryptoStepProps) => {
               </a>
             </div>
 
-            <Button onClick={handleDeBridgeClick} className="w-full flex items-center gap-2">
-              <ExternalLink className="h-4 w-4" />
-              Get {currency?.tokenSymbol} with deBridge
-            </Button>
-
+            <div className="space-y-3">
+              <Button onClick={handleJumperClick} className="w-full flex items-center gap-2">
+                <ExternalLink className="h-4 w-4" />
+                Get {currency?.tokenSymbol} with Jumper
+              </Button>
+              <Button onClick={handleDeBridgeClick} className="w-full flex items-center gap-2">
+                <ExternalLink className="h-4 w-4" />
+                Get {currency?.tokenSymbol} with deBridge
+              </Button>
+            </div>
             <div className="text-xs text-muted-foreground">
               By proceeding, you acknowledge that the service is provided by third parties and that you are entering
               into the{" "}

--- a/src/hooks/useJumperUrl.tsx
+++ b/src/hooks/useJumperUrl.tsx
@@ -1,0 +1,18 @@
+import { currencies } from "@/constants";
+import { useUser } from "@/context/UserContext";
+import { useMemo } from "react";
+
+export const useJumperUrl = () => {
+  const { safeConfig } = useUser();
+  const currency = useMemo(() => {
+    if (!safeConfig?.fiatSymbol) return null;
+    return currencies[safeConfig.fiatSymbol];
+  }, [safeConfig]);
+
+  const url = useMemo(() => {
+    if (!currency || !safeConfig?.address) return null;
+    return `https://jumper.exchange/?fromChain=1&fromToken=0x0000000000000000000000000000000000000000&toAddress=${safeConfig.address}&toChain=100&toToken=${currency.address}`;
+  }, [currency, safeConfig?.address]);
+
+  return url;
+};


### PR DESCRIPTION
**Closes https://linear.app/gnosis-pay/issue/ENG-3228/add-some-more-partners-to-add-funds-with-deep-links**

## 📝 Description

Cow doesn't allow to select EURe, and to change the receiver address
LIFI is only a protocol and has no hosted UI -> Jumper is fine for this
Swaps also has no way to change the receiver with a deep link

Sooo I just added jumper, and a link to the help center that explains everything and gives some more links.

## 📸 Visual Changes


<img width="927" height="919" alt="image" src="https://github.com/user-attachments/assets/aa3f56b1-d848-4439-b87e-cc8f01e0515e" />
