### PR TITLE
feat: add redirect in partners page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,10 @@ const publicRoutes = [
     path: "/welcome",
     element: <Navigate to="/" replace />,
   },
+  {
+    path: "/activation/choose-partner",
+    element: <Navigate to="/partners" replace />,
+  },
 ];
 
 function ProtectedLayout({ checkForSignup }: { checkForSignup?: boolean }) {


### PR DESCRIPTION
Part of the deprecation of v1 ([issue](https://linear.app/gnosis-pay/issue/ENG-3410/create-partner-activation-page-in-new-ui)), goal is making sure old non authed endpoints still work