### PR TITLE
Show /dispute error if any

### DIFF
--- a/src/components/modals/transaction-details/dispute-section.tsx
+++ b/src/components/modals/transaction-details/dispute-section.tsx
@@ -73,7 +73,12 @@ export const DisputeSection = ({ threadId, onBack }: DisputeSectionProps) => {
         disputeReason: selectedReason,
       },
     })
-      .then(() => {
+      .then(({ error }) => {
+        if (error) {
+          setDisputeError(extractErrorMessage(error, "Failed to submit dispute"));
+          return;
+        }
+
         setDisputeStep(DisputeStep.Success);
         setSelectedReason("");
       })


### PR DESCRIPTION
Now that we have possible errors on this endpoint, we should show them

## 📸 Visual Changes

<img width="929" height="538" alt="image" src="https://github.com/user-attachments/assets/c40fd4d7-e40a-44e2-b4cc-5c8c166b0e4a" />

