### PR TITLE
Tighten the card flow to prevent errors

### DIFF
--- a/src/components/card-order/SetPinStep.tsx
+++ b/src/components/card-order/SetPinStep.tsx
@@ -74,6 +74,19 @@ export const SetPinStep = ({ cardToken }: SetPinStepProps) => {
         <p className="text-muted-foreground mt-2">
           Your card has been created successfully. Please set a secure PIN to complete the process.
         </p>
+        <StandardAlert
+          variant="info"
+          description={
+            <p className="text-left">
+              This step is required to use your card.
+              <br />
+              There will be no way to set the PIN after this step.
+              <br />
+              Do not refresh or close this page until the PIN is set.
+            </p>
+          }
+          className="mt-4"
+        />
       </div>
       {error && <StandardAlert variant="destructive" description={error} className="mb-6" />}
 


### PR DESCRIPTION
**Closes https://linear.app/gnosis-pay/issue/ENG-3441/frontend-issue-after-order-completion-and-pin-flow**

## 📝 Description

- Make sure we can only go forward if the order is in the right state (not done, not canceled)
- Do not allow to cancel if the order is done (it'd fail)
- Clearly mention the PIN flow is critical & needs to be done **now** bc there'll not be any other way down the line

## 📸 Visual Changes

<img width="2523" height="514" alt="image" src="https://github.com/user-attachments/assets/4490084a-0e24-498d-a632-3401154b67e3" />
<img width="2141" height="1188" alt="image" src="https://github.com/user-attachments/assets/359b2eda-eef1-4a14-89df-93ac7d0b46a5" />

