### PR TITLE
Remove deprecated header

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -68,11 +68,6 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files \$uri /index.html;
-        # Security Headers
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Content-Security-Policy "frame-ancestors https://app.safe.global; script-src 'self' 'unsafe-inline' https:; object-src 'none'; base-uri 'none'" always;
     }
 

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -68,6 +68,9 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files \$uri /index.html;
+        # Security Headers
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Content-Security-Policy "frame-ancestors https://app.safe.global; script-src 'self' 'unsafe-inline' https:; object-src 'none'; base-uri 'none'" always;
     }
 

--- a/public/_header
+++ b/public/_header
@@ -1,8 +1,4 @@
 /*
-  X-Content-Type-Options: nosniff
-  X-XSS-Protection: 1; mode=block
-  Referrer-Policy: strict-origin-when-cross-origin
-  Strict-Transport-Security: max-age=31536000; includeSubDomains
   Content-Security-Policy: frame-ancestors https://app.safe.global; script-src 'self' 'unsafe-inline' https:; object-src 'none'; base-uri 'none'
 
 /manifest.json

--- a/public/_header
+++ b/public/_header
@@ -1,4 +1,6 @@
 /*
+  X-Content-Type-Options: nosniff
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
   Content-Security-Policy: frame-ancestors https://app.safe.global; script-src 'self' 'unsafe-inline' https:; object-src 'none'; base-uri 'none'
 
 /manifest.json


### PR DESCRIPTION
The header dance continues. I don't have too much time rn to dive deeper into the optimal CSP and config (we need some changes in the build afaik), the script-src unsafe-inline in particular should be tightened. But it needs to be checked carefully.

[referer policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy) is actually the default, [x-xss protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection) is deprecated. 

The 2 others remaining are ok:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security