### PR TITLE
Rounding and 2 decimals for GNO and rewards

### DIFF
--- a/src/components/rewards.tsx
+++ b/src/components/rewards.tsx
@@ -45,11 +45,17 @@ export const Rewards = () => {
     return rewardsData.cashbackRate + (rewardsData.isOg ? 1 : 0);
   }, [rewardsData]);
 
+  const totalCashbackRateFormatted = useMemo(() => {
+    return totalCashbackRate.toFixed(2);
+  }, [totalCashbackRate]);
+
   const formattedGnoBalance = useMemo(() => {
     if (!rewardsData) return "0";
-    return rewardsData.gnoBalance.toLocaleString("en-US", {
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 1,
+    // Floor to 2 decimal places: 0.616 becomes 0.61
+    const flooredValue = Math.floor(rewardsData.gnoBalance * 100) / 100;
+    return flooredValue.toLocaleString("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
     });
   }, [rewardsData]);
 
@@ -84,7 +90,7 @@ export const Rewards = () => {
             <span className="text-sm font-medium text-foreground">Cashback</span>
             {rewardsData?.isOg && <OgnftBadge />}
             <div className="flex-1" />
-            <span className="text-sm font-medium text-foreground">{totalCashbackRate.toFixed(1)}%</span>
+            <span className="text-sm font-medium text-foreground">{totalCashbackRateFormatted}%</span>
           </div>
           <div className="flex justify-between items-center">
             <span className="text-sm text-muted-foreground">GNO balance</span>


### PR DESCRIPTION
**Closes https://linear.app/gnosis-pay/issue/ENG-3460/adjust-cashback-and-gno-balance-rounding-to-2-decimal-points**

## 📝 Description

Rounding floor for the GNO balance 0.646 shows 0.64
Rounding normal for the cashback 2.606 shows 2.61


## 📸 Visual Changes

<img width="553" height="254" alt="image" src="https://github.com/user-attachments/assets/2963dce7-8374-4e8e-b1ae-4d2161d310a8" />
