### PR TITLE
Tweak zendesk on Mobile

### DIFF
--- a/src/components/cards-carousel/card-skeleton.tsx
+++ b/src/components/cards-carousel/card-skeleton.tsx
@@ -3,7 +3,7 @@ import CardFront from "./card-front";
 
 export const CardSkeleton = () => {
   return (
-    <div className="rounded-xl overflow-hidden w-xs bg-black relative">
+    <div className="rounded-xl overflow-hidden w-xs bg-black relative lg:mx-0 mx-auto">
       <CardFront />
       <div className="absolute left-4 bottom-4 flex flex-col items-start z-10">
         <div className="mb-1">

--- a/src/components/nav/footer.tsx
+++ b/src/components/nav/footer.tsx
@@ -1,14 +1,35 @@
 import { ModeToggle } from "../theme-toggle";
 import { NavLink } from "react-router-dom";
 import { menuRoutes } from "@/App";
+import { MessageCircle } from "lucide-react";
+import { useZendesk } from "react-use-zendesk";
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 export const FooterNavBar = () => {
+  const { open, show } = useZendesk();
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const handleSupportClick = useCallback(() => {
+    open();
+    show();
+    setIsAnimating(true);
+
+    // Stop animation after 2 seconds
+    const timer = setTimeout(() => {
+      setIsAnimating(false);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [open, show]);
+
   return (
     <>
       {/* Spacer for header height on mobile */}
       <div className="h-20 lg:hidden" />
       <footer className="fixed bottom-0 left-0 w-full border-t lg:hidden py-2 bg-background z-50">
-        <div className="relative flex h-14 items-center px-4">
+        <div className="relative flex h-10 items-center px-4">
           {/* Centered menu items */}
           <div className="flex-1 flex items-center justify-center gap-6">
             {menuRoutes.map((route) => (
@@ -21,13 +42,17 @@ export const FooterNavBar = () => {
                   }`
                 }
               >
-                <route.icon size={24} />
+                <route.icon size={18} />
                 <span className="text-xs">{route.label}</span>
               </NavLink>
             ))}
           </div>
-          {/* Absolute positioned ModeToggle on the right */}
-          <div className="absolute right-4 top-1/2 -translate-y-1/2">
+          {/* Absolute positioned buttons on the right */}
+          <div className="absolute right-4 top-1/2 -translate-y-1/2 flex gap-2">
+            <Button variant="outline" size="icon" onClick={handleSupportClick}>
+              <MessageCircle className={cn("h-[1.2rem] w-[1.2rem]", isAnimating && "animate-ping")} />
+              <span className="sr-only">Open support</span>
+            </Button>
             <ModeToggle />
           </div>
         </div>

--- a/src/hooks/useZendeskUserId.tsx
+++ b/src/hooks/useZendeskUserId.tsx
@@ -1,14 +1,46 @@
 import { ZENDESK_PARTNER_TAG_VALUE, ZENDESK_USER_ID_FIELD_ID } from "@/constants";
 import { useUser } from "@/context/UserContext";
-import { useEffect } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useZendesk } from "react-use-zendesk";
 
 export const useZendeskUserId = () => {
   const { user } = useUser();
-  const { isOpen, setConversationFields, setConversationTags } = useZendesk();
+  const { isOpen, setConversationFields, setConversationTags, hide } = useZendesk();
   const [isFielsdSet, setIsFielsdSet] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
 
+  // Detect mobile viewport
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 1024); // lg breakpoint
+    };
+
+    checkMobile();
+    window.addEventListener("resize", checkMobile);
+    return () => window.removeEventListener("resize", checkMobile);
+  }, []);
+
+  // Hide widget on mobile by default
+  useEffect(() => {
+    const hideOnMobile = () => {
+      if (isMobile && !isOpen) {
+        hide();
+      }
+    };
+
+    // Hide widget on mobile by default
+    hideOnMobile();
+
+    // hide widget after 1 second
+    // because it's lazy loaded
+    const timer = setTimeout(() => {
+      hideOnMobile();
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [isMobile, hide, isOpen]);
+
+  // Set user ID and tags when widget is opened
   useEffect(() => {
     if (!isOpen || isFielsdSet) {
       return;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,12 +36,12 @@ export const Home = () => {
           </div>
 
           {/* Partner Banner - After Balances on mobile, Row 1 Right on desktop */}
-          <div className="m-4 lg:mx-0 lg:col-span-1 lg:col-start-3 lg:row-start-1 lg:mb-0">
+          <div className="m-4 lg:mx-0 lg:mb-0 lg:col-span-1 lg:col-start-3 lg:row-start-1">
             <PartnerBanner />
           </div>
 
           {/* Rewards and Cards - After Partner on mobile, Row 2 Right on desktop */}
-          <div className="m-4 lg:mx-0 lg:col-span-1 lg:col-start-3 lg:row-start-2 lg:mb-0">
+          <div className="m-4 lg:m-0 lg:col-span-1 lg:col-start-3 lg:row-start-2">
             <div className="flex items-center justify-between mb-4">
               <h1 className="font-bold text-secondary text-lg">
                 Rewards <StatusHelpIcon type="rewards" />


### PR DESCRIPTION
**Closes https://linear.app/gnosis-pay/issue/ENG-3476/tweak-zendesk-widget-on-mobile**
Closes too https://linear.app/gnosis-pay/issue/ENG-3475/cards-page-jumping-on-mobile

## 📝 Description
- UI was jumping on the card view, it's fixed
- Hide the whole Zendesk widget on mobile (no other option unfortunately)
- show it on click on the menu bar
- with animation bc the widget takes a bit to display
- smaller menu bar

There's still a little glitch on close, the Zendesk button shows shortly, but I'm willing to accept this for now, it's much better than what we had.

## 📸 Visual Changes

https://github.com/user-attachments/assets/60c93bb0-1174-4990-b41e-d4f5b744c467



https://github.com/user-attachments/assets/20c0a631-46b5-458f-adcd-864ad294e324


