### PR TITLE
Add Disconnect button on mobile on the Acccount page

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -10,6 +10,8 @@ import {
 import { DailyLimitModal } from "@/components/modals/daily-limit";
 import { SafeOwnersModal } from "@/components/modals/safe-owners";
 import { HELP_CENTER_URL } from "@/constants";
+import { useAccountModal } from "@rainbow-me/rainbowkit";
+import { Button } from "@/components/ui/button";
 
 enum ModalType {
   NONE = "none",
@@ -23,10 +25,14 @@ enum ModalType {
 export const AccountRoute = () => {
   const [openModal, setOpenModal] = useState<ModalType>(ModalType.NONE);
   const closeModal = () => setOpenModal(ModalType.NONE);
+  const { openAccountModal } = useAccountModal();
 
   return (
     <div className="w-full max-w-xl mx-auto p-4 space-y-8">
       <UserProfileHeader />
+      <div className="lg:hidden w-full flex justify-center mb-4">
+        <Button onClick={() => openAccountModal?.()}>Disconnect</Button>
+      </div>
       <div className="space-y-4">
         <h2 className="text-lg font-medium text-foreground">Account</h2>
         <div className="space-y-3">


### PR DESCRIPTION
Closes https://linear.app/gnosis-pay/issue/ENG-3463/webapp-v2-on-mobile-doesnt-show-a-logout-button

## 📝 Description

Disconnect button on Mobile in the /accounts page

## 📸 Visual Changes

<img width="760" height="1351" alt="image" src="https://github.com/user-attachments/assets/d68e5815-e8d0-4725-b3b3-b8a724b9ecbf" />
