### PR TITLE
fix: remove duplicate push trigger from deploy-ui.yml

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -1,13 +1,8 @@
 name: Deploy UI to Production
 
 on:
-  push:
-    branches:
-      - main
-    # paths:
-    #   - 'services/ui/**'
-  workflow_dispatch:
-  workflow_call:
+  workflow_dispatch: # allows manual redeploy from GitHub Actions UI without a new commit
+  workflow_call: # called by docker-ui.yml after image is built and pushed to ECR
     
 permissions:
   id-token: write


### PR DESCRIPTION
Ticket : https://linear.app/gnosis-pay/issue/DOP-528/github-workflows-diagnose-production-ui-workflow-erros

fix: remove duplicate push trigger from deploy-ui.yml

deploy-ui.yml had a push trigger alongside being called via workflow_call from docker-ui.yml. Every merge to main fired two independent deployments against the same ECS service — one before the image existed in ECR, one after  causing false circuit breaker failures.

New flow : 
PR merges to main
        │
        └──> docker-ui.yml fires (push trigger)
                builds image (~2-3 min)
                pushes image 6fb31dcf... to ECR at 17:53:29
                calls deploy-ui.yml via workflow_call
                        → registers ui:282 with image 6fb31dcf... (image already exists)
                        → ECS starts task, pulls image immediately (no race)
                        → task registers to ALB
                        → deployment completes
                        → GH Actions confirms 