### PR TITLE
feat: update banner wording for a case when a Safe was affected and it had balance

### DIFF
--- a/src/components/ui/incident-banner.tsx
+++ b/src/components/ui/incident-banner.tsx
@@ -71,7 +71,9 @@ export function IncidentBanner({ className }: IncidentBannerProps) {
 
         <div className="flex-1 min-w-0 pr-6">
           <p className="font-bold text-foreground text-base sm:text-lg leading-tight">
-            Your Gnosis Pay card is back up and running.
+            {affected && hasPreHackBalance
+              ? "Your Gnosis Pay card is coming back."
+              : "Your Gnosis Pay card is back up and running."}
           </p>
 
           {!affected && hasPreHackBalance && (
@@ -95,9 +97,14 @@ export function IncidentBanner({ className }: IncidentBannerProps) {
           )}
 
           {affected && hasPreHackBalance && (
-            <p className="mt-2 text-sm sm:text-base text-foreground leading-snug">
-              We've restored your balance and issued you a new Gnosis Pay Safe. Your previous Safe is no longer secure. Do not use your old Safe address again: anything you send there will be lost.
-            </p>
+            <>
+              <p className="mt-1 text-sm sm:text-base text-foreground leading-snug">
+                We've issued you a new Gnosis Pay Safe because your previous Safe is no longer secure. Do not use your old Safe address again: anything you send there will be lost.
+              </p>
+              <p className="mt-1 text-sm sm:text-base text-foreground leading-snug">
+                Funds are now being restored and will appear on your balance by EOD Sunday, June 7th.
+              </p>
+            </>
           )}
 
           {affected && !hasPreHackBalance && (

--- a/tests/banners.spec.ts
+++ b/tests/banners.spec.ts
@@ -58,7 +58,9 @@ test.describe("Incident banner - 4 cases", () => {
     const banner = page.getByTestId("incident-notice-banner");
     await expect(banner).toBeVisible();
     await expect(banner).toContainText("Your Gnosis Pay card is coming back.");
-    await expect(banner).toContainText("Funds are now being restored and will appear on your balance by EOD Sunday, June 7th.");
+    await expect(banner).toContainText(
+      "Funds are now being restored and will appear on your balance by EOD Sunday, June 7th.",
+    );
     await expect(banner).toContainText("Do not use your old Safe address again");
   });
 

--- a/tests/banners.spec.ts
+++ b/tests/banners.spec.ts
@@ -57,8 +57,8 @@ test.describe("Incident banner - 4 cases", () => {
     await setupBannerTest(page, OLD_SAFE_AFFECTED_WITH_BALANCE);
     const banner = page.getByTestId("incident-notice-banner");
     await expect(banner).toBeVisible();
-    await expect(banner).toContainText("Your Gnosis Pay card is back up and running.");
-    await expect(banner).toContainText("We've restored your balance");
+    await expect(banner).toContainText("Your Gnosis Pay card is coming back.");
+    await expect(banner).toContainText("Funds are now being restored and will appear on your balance by EOD Sunday, June 7th.");
     await expect(banner).toContainText("Do not use your old Safe address again");
   });
 


### PR DESCRIPTION
<img width="1723" height="122" alt="Screenshot 2026-06-05 at 21 32 57" src="https://github.com/user-attachments/assets/22987495-2ad1-4fd9-a6ef-284c62281435" />
