### PR TITLE
Old account-kit for old safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "test:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@gnosispay/account-kit": "5.1.1",
-    "@gnosispay/account-kit-next": "npm:@gnosispay/account-kit@5.0.0",
+    "@gnosispay/account-kit": "4.10.1",
+    "@gnosispay/account-kit-next": "npm:@gnosispay/account-kit@5.1.1",
     "@gnosispay/pse-sdk": "2.0.1",
     "@radix-ui/react-checkbox": "^1.3.7",
     "@radix-ui/react-dialog": "^1.1.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,11 +14,11 @@ importers:
   .:
     dependencies:
       '@gnosispay/account-kit':
-        specifier: 5.1.1
-        version: 5.1.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        specifier: 4.10.1
+        version: 4.10.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@gnosispay/account-kit-next':
-        specifier: npm:@gnosispay/account-kit@5.0.0
-        version: '@gnosispay/account-kit@5.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)'
+        specifier: npm:@gnosispay/account-kit@5.1.1
+        version: '@gnosispay/account-kit@5.1.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)'
       '@gnosispay/pse-sdk':
         specifier: 2.0.1
         version: 2.0.1
@@ -163,9 +163,6 @@ importers:
         version: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)
 
 packages:
-
-  '@adraffy/ens-normalize@1.10.1':
-    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
@@ -398,8 +395,8 @@ packages:
   '@gnosis.pm/zodiac@3.5.2':
     resolution: {integrity: sha512-ra4iGOF8gPhYFZTQeH6mRC9TinY0eZ/l+uGhyskR46+IHjH3OFQbmfRu+UYJedYBka3vT3ai0iidKGDKRt61yA==}
 
-  '@gnosispay/account-kit@5.0.0':
-    resolution: {integrity: sha512-+wqg8++vxuPkpJW3Z1BZPIEDVjfEd/Wf/0zWRZSSWtisfYBFqgRhYzSpkY9Wo/zMmrYsUQuErx736HHg58hjag==}
+  '@gnosispay/account-kit@4.10.1':
+    resolution: {integrity: sha512-2C9POPvVALrjLov34fIvNKzR7yl6pilTcoTJUXKEDHkGWXI0xmGT1dkxsDJcRO9IP4JI0OYKP+TCgkyi6VfYjQ==}
 
   '@gnosispay/account-kit@5.1.1':
     resolution: {integrity: sha512-xmRKBkMar9bRHTO8w3qfueP6oymS66dsOR/p+6c612dwf/G8VSKK0axqz4mNZwxAChey65Gv6yajbYRqztIwMQ==}
@@ -2429,10 +2426,6 @@ packages:
   ethers@5.8.0:
     resolution: {integrity: sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==}
 
-  ethers@6.16.0:
-    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
-    engines: {node: '>=14.0.0'}
-
   ethers@6.17.0:
     resolution: {integrity: sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==}
     engines: {node: '>=14.0.0'}
@@ -3718,18 +3711,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
@@ -3873,8 +3854,6 @@ packages:
         optional: true
 
 snapshots:
-
-  '@adraffy/ens-normalize@1.10.1': {}
 
   '@adraffy/ens-normalize@1.11.1': {}
 
@@ -4321,10 +4300,6 @@ snapshots:
     dependencies:
       ethers: 5.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
-  '@gnosis.pm/safe-contracts@1.3.0(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
-    dependencies:
-      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-
   '@gnosis.pm/safe-contracts@1.3.0(ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       ethers: 6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -4340,13 +4315,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@gnosispay/account-kit@5.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+  '@gnosispay/account-kit@4.10.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
-      '@gnosis.pm/safe-contracts': 1.3.0(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@gnosis.pm/safe-contracts': 1.3.0(ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@gnosis.pm/zodiac': 3.5.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@safe-global/safe-deployments': 1.28.0
       '@safe-global/safe-singleton-factory': 1.0.16
-      ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ethers: 6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       typescript: 5.3.2
     transitivePeerDependencies:
       - bufferutil
@@ -4538,7 +4513,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       lodash: 4.18.1
       pony-cause: 2.1.11
-      semver: 7.8.0
+      semver: 7.8.3
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -4562,7 +4537,7 @@ snapshots:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@10.2.2)
       pony-cause: 2.1.11
-      semver: 7.8.0
+      semver: 7.8.3
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -5427,7 +5402,7 @@ snapshots:
 
   '@safe-global/safe-deployments@1.28.0':
     dependencies:
-      semver: 7.8.0
+      semver: 7.8.3
 
   '@safe-global/safe-gateway-typescript-sdk@3.23.1': {}
 
@@ -7192,19 +7167,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.1
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@types/node': 22.7.5
-      aes-js: 4.0.0-beta.5
-      tslib: 2.7.0
-      ws: 8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -8441,11 +8403,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.1.0
-      utf-8-validate: 5.0.10
-
-  ws@8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10

--- a/tests/utils/anvil.ts
+++ b/tests/utils/anvil.ts
@@ -354,7 +354,7 @@ export const GNOSIS_TOKENS = {
   wstETH: {
     address: "0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6" as Address,
     decimals: 18,
-    whale: "0x458cD345B4C05e8DF39d0A07220feb4Ec19F5e6f",
+    whale: "0x509Ad7278A2F6530Bc24590C83E93fAF8fd46E99",
   },
   // GNO
   GNO: {


### PR DESCRIPTION
The old safe needs the older version of the account-kit (v4) to check for the signers.